### PR TITLE
Fix endpoint reconcile handling of identifiers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/cilium/cilium v1.15.8
 	github.com/hashicorp/nomad/api v0.0.0-20230719205936-8d2894699319
 	github.com/sirupsen/logrus v1.9.3
+	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.11.2
 	go.uber.org/zap v1.26.0
 )
@@ -104,6 +105,7 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.18.1 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -363,8 +363,9 @@ github.com/spf13/viper v1.18.1/go.mod h1:EKmWIqdnk5lOcmR72yw6hS+8OPYcwD0jteitLMV
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/reapers/endpoints_test.go
+++ b/reapers/endpoints_test.go
@@ -3,8 +3,6 @@ package reapers
 import (
 	"context"
 	"fmt"
-	"reflect"
-	"slices"
 	"testing"
 	"time"
 
@@ -12,73 +10,77 @@ import (
 	endpoint_id "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/labelsfilter"
 	nomad_api "github.com/hashicorp/nomad/api"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 type allocationInfoMock struct {
-	infoFn func(allocID string, q *nomad_api.QueryOptions) (*nomad_api.Allocation, *nomad_api.QueryMeta, error)
+	mock.Mock
 }
 
 func (p *allocationInfoMock) Info(allocID string, q *nomad_api.QueryOptions) (*nomad_api.Allocation, *nomad_api.QueryMeta, error) {
-	if p != nil && p.infoFn != nil {
-		return p.infoFn(allocID, q)
+	args := p.Called(allocID, q)
+
+	r0 := args.Get(0)
+	if r0 == nil {
+		return nil, args.Get(1).(*nomad_api.QueryMeta), args.Error(2)
 	}
-	return nil, nil, nil
+
+	return args.Get(0).(*nomad_api.Allocation), args.Get(1).(*nomad_api.QueryMeta), args.Error(2)
 }
 
 type eventStreamerMock struct {
-	streamFn func(ctx context.Context, topics map[nomad_api.Topic][]string, index uint64, q *nomad_api.QueryOptions) (<-chan *nomad_api.Events, error)
+	mock.Mock
 }
 
 func (p *eventStreamerMock) Stream(ctx context.Context, topics map[nomad_api.Topic][]string, index uint64, q *nomad_api.QueryOptions) (<-chan *nomad_api.Events, error) {
-	if p != nil && p.streamFn != nil {
-		return p.streamFn(ctx, topics, index, q)
-	}
-	return nil, nil
+	args := p.Called(ctx, topics, index, q)
+	return args.Get(0).(chan *nomad_api.Events), args.Error(1)
 }
 
 type endpointUpdaterMock struct {
-	endpointListFn   func() ([]*models.Endpoint, error)
-	endpointGetFn    func(id string) (*models.Endpoint, error)
-	endpointPatchFn  func(id string, ep *models.EndpointChangeRequest) error
-	endpointDeleteFn func(id string) error
+	mock.Mock
 }
 
 func (p *endpointUpdaterMock) EndpointList() ([]*models.Endpoint, error) {
-	if p != nil && p.endpointListFn != nil {
-		return p.endpointListFn()
-	}
-	return nil, nil
+	args := p.Called()
+	return args.Get(0).([]*models.Endpoint), args.Error(1)
 }
 
 func (p *endpointUpdaterMock) EndpointGet(id string) (*models.Endpoint, error) {
-	if p != nil && p.endpointGetFn != nil {
-		return p.endpointGetFn(id)
-	}
-	return nil, nil
+	args := p.Called(id)
+	return args.Get(0).(*models.Endpoint), args.Error(1)
 }
 
 func (p *endpointUpdaterMock) EndpointPatch(id string, ep *models.EndpointChangeRequest) error {
-	if p != nil && p.endpointPatchFn != nil {
-		return p.endpointPatchFn(id, ep)
-	}
-	return nil
+	args := p.Called(id, ep)
+	return args.Error(0)
 }
 
 func (p *endpointUpdaterMock) EndpointDelete(id string) error {
-	if p != nil && p.endpointDeleteFn != nil {
-		return p.endpointDeleteFn(id)
-	}
-	return nil
+	args := p.Called(id)
+	return args.Error(0)
 }
 
-func TestEndpointReconcile(t *testing.T) {
+func TestEndpointReconcileNoEndpoints(t *testing.T) {
+	eum := new(endpointUpdaterMock)
+	eum.On("EndpointList").Return([]*models.Endpoint{}, nil).Once()
+
+	_, err := NewEndpointReaper(eum, nil, nil, "nodeID")
+	assert.Nil(t, err)
+
+	eum.AssertExpectations(t)
+}
+
+func TestEndpointReconcileOneEndpoints(t *testing.T) {
 	labelsfilter.ParseLabelPrefixCfg([]string{"netreap:.*"}, "")
 
 	endpointOne := &models.Endpoint{
 		ID: 1,
 		Status: &models.EndpointStatus{
 			ExternalIdentifiers: &models.EndpointIdentifiers{
-				ContainerID: "containerID",
+				CniAttachmentID: "containerID:eth0",
 			},
 			Labels: &models.LabelConfigurationStatus{
 				SecurityRelevant: models.Labels{"reserved:init"},
@@ -93,233 +95,132 @@ func TestEndpointReconcile(t *testing.T) {
 		Job: &nomad_api.Job{
 			Meta: map[string]string{},
 		},
-	}
-	endpointOneLabels := models.Labels{
-		"netreap:nomad.job_id=jobID",
-		"netreap:nomad.namespace=namespace",
-		"netreap:nomad.task_group_id=taskGroup",
-	}
-
-	tests := []struct {
-		name             string
-		cilium           *endpointUpdaterMock
-		nomadAllocations *allocationInfoMock
-		shouldErr        bool
-	}{
-		{
-			"No Endpoints",
-			&endpointUpdaterMock{
-				endpointListFn: func() ([]*models.Endpoint, error) {
-					return []*models.Endpoint{}, nil
-				},
-				endpointPatchFn: func(id string, ep *models.EndpointChangeRequest) error {
-					t.Fatalf("unexpected call to patch endpoint")
-					return nil
-				},
-				endpointDeleteFn: func(id string) error {
-					t.Fatalf("unexpected call to delete endpoint")
-					return nil
-				},
-			},
-			&allocationInfoMock{
-				infoFn: func(allocID string, q *nomad_api.QueryOptions) (*nomad_api.Allocation, *nomad_api.QueryMeta, error) {
-					t.Fatalf("unexpected call to allocation info")
-					return nil, nil, nil
-				},
-			},
-			false,
-		},
-		{
-			"One endpoint",
-			&endpointUpdaterMock{
-				endpointListFn: func() ([]*models.Endpoint, error) {
-					return []*models.Endpoint{endpointOne}, nil
-				},
-				endpointPatchFn: func(endpointID string, ep *models.EndpointChangeRequest) error {
-					expectedID := endpoint_id.NewCiliumID(endpointOne.ID)
-					expectedContainerID := endpointOne.Status.ExternalIdentifiers.ContainerID
-
-					if endpointID != expectedID {
-						t.Errorf("wrong endpoint ID passed, expected %v, got %v", expectedID, endpointID)
-					}
-
-					if ep.ContainerID != expectedContainerID {
-						t.Errorf("wrong container ID passed, expected %v, got %v", expectedContainerID, ep.ContainerID)
-					}
-
-					slices.Sort(ep.Labels)
-					slices.Sort(endpointOneLabels)
-
-					if !reflect.DeepEqual(ep.Labels, endpointOneLabels) {
-						t.Errorf("wrong labels, expected %v, got %v", endpointOneLabels, ep.Labels)
-					}
-
-					return nil
-				},
-				endpointDeleteFn: func(id string) error {
-					t.Fatalf("unexpected call to delete endpoint")
-					return nil
-				},
-			},
-			&allocationInfoMock{
-				infoFn: func(allocID string, q *nomad_api.QueryOptions) (*nomad_api.Allocation, *nomad_api.QueryMeta, error) {
-					expectedContainerID := endpointOne.Status.ExternalIdentifiers.ContainerID
-					if allocID != expectedContainerID {
-						t.Errorf("wrong container ID passed, expected %v, got %v", expectedContainerID, allocID)
-					}
-					return allocationOne, nil, nil
-				},
-			},
-			false,
-		},
-		{
-			"No matching endpoint",
-			&endpointUpdaterMock{
-				endpointListFn: func() ([]*models.Endpoint, error) {
-					return []*models.Endpoint{endpointOne}, nil
-				},
-				endpointPatchFn: func(endpointID string, ep *models.EndpointChangeRequest) error {
-					expectedID := endpoint_id.NewCiliumID(endpointOne.ID)
-					expectedContainerID := endpointOne.Status.ExternalIdentifiers.ContainerID
-
-					if endpointID != expectedID {
-						t.Errorf("wrong endpoint ID passed, expected %v, got %v", expectedID, endpointID)
-					}
-
-					if ep.ContainerID != expectedContainerID {
-						t.Errorf("wrong container ID passed, expected %v, got %v", expectedContainerID, ep.ContainerID)
-					}
-
-					if !reflect.DeepEqual(ep.Labels, endpointOneLabels) {
-						t.Errorf("wrong labels, expected %v, got %v", endpointOneLabels, ep.Labels)
-					}
-
-					return nil
-				},
-				endpointDeleteFn: func(endpointID string) error {
-					expectedID := endpoint_id.NewCiliumID(endpointOne.ID)
-					if endpointID != expectedID {
-						t.Errorf("wrong endpoint ID passed, expected %v, got %v", expectedID, endpointID)
-					}
-					return nil
-				},
-			},
-			&allocationInfoMock{
-				infoFn: func(allocID string, q *nomad_api.QueryOptions) (*nomad_api.Allocation, *nomad_api.QueryMeta, error) {
-					expectedContainerID := endpointOne.Status.ExternalIdentifiers.ContainerID
-					if allocID != expectedContainerID {
-						t.Errorf("wrong container ID passed, expected %v, got %v", expectedContainerID, allocID)
-					}
-					return nil, nil, nil
-				},
-			},
-			false,
+		NetworkStatus: &nomad_api.AllocNetworkStatus{
+			InterfaceName: "eth0",
 		},
 	}
 
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			reaper, err := NewEndpointReaper(tt.cilium, tt.nomadAllocations, nil, "")
-			if err != nil {
-				t.Fatalf("unexpected error creating poller %v", err)
-			}
-
-			err = reaper.reconcile()
-
-			if tt.shouldErr && err == nil {
-				t.Error("expected error but got <nil>")
-			}
-			if !tt.shouldErr && err != nil {
-				t.Errorf("unexpected error %v", err)
-			}
+	eum := new(endpointUpdaterMock)
+	eum.On("EndpointList").Return([]*models.Endpoint{endpointOne}, nil).Once()
+	eum.On("EndpointPatch", endpoint_id.NewCiliumID(endpointOne.ID), mock.MatchedBy(func(req *models.EndpointChangeRequest) bool {
+		assert.ElementsMatch(t, req.Labels, models.Labels{
+			"netreap:nomad.job_id=jobID",
+			"netreap:nomad.namespace=namespace",
+			"netreap:nomad.task_group_id=taskGroup",
 		})
+		return true
+	})).Return(nil).Once()
+
+	aim := new(allocationInfoMock)
+	aim.On("Info", "containerID", mock.MatchedBy(func(q *nomad_api.QueryOptions) bool {
+		return q.Namespace == "*"
+	})).Return(allocationOne, &nomad_api.QueryMeta{}, nil).Once()
+
+	esm := new(eventStreamerMock)
+
+	_, err := NewEndpointReaper(eum, aim, esm, "nodeID")
+	assert.Nil(t, err)
+
+	eum.AssertExpectations(t)
+	aim.AssertExpectations(t)
+	esm.AssertExpectations(t)
+}
+
+func TestEndpointReconcileOneEndpointToDelete(t *testing.T) {
+	labelsfilter.ParseLabelPrefixCfg([]string{"netreap:.*"}, "")
+
+	endpointOne := &models.Endpoint{
+		ID: 1,
+		Status: &models.EndpointStatus{
+			ExternalIdentifiers: &models.EndpointIdentifiers{
+				CniAttachmentID: "containerID:eth0",
+			},
+			Labels: &models.LabelConfigurationStatus{
+				SecurityRelevant: models.Labels{
+					"netreap:nomad.job_id=jobID",
+					"netreap:nomad.namespace=namespace",
+					"netreap:nomad.task_group_id=taskGroup",
+				},
+			},
+		},
 	}
+
+	eum := new(endpointUpdaterMock)
+	eum.On("EndpointList").Return([]*models.Endpoint{endpointOne}, nil).Once()
+	eum.On("EndpointDelete", endpoint_id.NewCiliumID(endpointOne.ID)).Return(nil).Once()
+
+	aim := new(allocationInfoMock)
+	aim.On("Info", "containerID", mock.MatchedBy(func(q *nomad_api.QueryOptions) bool {
+		return q.Namespace == "*"
+	})).Return(nil, &nomad_api.QueryMeta{}, nil).Once()
+
+	esm := new(eventStreamerMock)
+
+	_, err := NewEndpointReaper(eum, aim, esm, "nodeID")
+	assert.Nil(t, err)
+
+	eum.AssertExpectations(t)
+	aim.AssertExpectations(t)
+	esm.AssertExpectations(t)
 }
 
 func TestEndpointRunErrorHandling(t *testing.T) {
-	cilium := &endpointUpdaterMock{
-		endpointListFn: func() ([]*models.Endpoint, error) {
-			return []*models.Endpoint{}, nil
-		},
-		endpointPatchFn: func(id string, ep *models.EndpointChangeRequest) error {
-			t.Fatalf("unexpected call to patch endpoint")
-			return nil
-		},
-		endpointDeleteFn: func(id string) error {
-			t.Fatalf("unexpected call to delete endpoint")
-			return nil
-		},
-	}
+	eum := new(endpointUpdaterMock)
+	eum.On("EndpointList").Return([]*models.Endpoint{}, nil).Once()
 
-	nomad := &allocationInfoMock{
-		infoFn: func(allocID string, q *nomad_api.QueryOptions) (*nomad_api.Allocation, *nomad_api.QueryMeta, error) {
-			t.Fatalf("unexpected call to allocation info")
-			return nil, nil, nil
-		},
-	}
+	aim := new(allocationInfoMock)
 
 	events := make(chan *nomad_api.Events, 3)
 
-	nomadEventStream := &eventStreamerMock{
-		streamFn: func(ctx context.Context, topics map[nomad_api.Topic][]string, index uint64, q *nomad_api.QueryOptions) (<-chan *nomad_api.Events, error) {
+	esm := new(eventStreamerMock)
+	esm.On("Stream", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 
-			// One normal event
-			events <- &nomad_api.Events{
-				Index: 1,
-				Err:   nil,
-				Events: []nomad_api.Event{
-					{
-						Topic: nomad_api.TopicAllocation,
-						Type:  "AllocationUpdated",
-					},
+		// One normal event
+		events <- &nomad_api.Events{
+			Index: 1,
+			Err:   nil,
+			Events: []nomad_api.Event{
+				{
+					Topic: nomad_api.TopicAllocation,
+					Type:  "AllocationUpdated",
 				},
-			}
+			},
+		}
 
-			// Should exit at this point with the returned error
-			events <- &nomad_api.Events{
-				Index: 2,
-				Err:   fmt.Errorf("fatal error"),
-			}
+		// Should exit at this point with the returned error
+		events <- &nomad_api.Events{
+			Index: 2,
+			Err:   fmt.Errorf("fatal error"),
+		}
 
-			// This event will not be consumed as the routine should exit
-			events <- &nomad_api.Events{
-				Index: 3,
-				Err:   nil,
-				Events: []nomad_api.Event{
-					{
-						Topic: nomad_api.TopicAllocation,
-						Type:  "AllocationUpdated",
-					},
+		// This event will not be consumed as the routine should exit
+		events <- &nomad_api.Events{
+			Index: 3,
+			Err:   nil,
+			Events: []nomad_api.Event{
+				{
+					Topic: nomad_api.TopicAllocation,
+					Type:  "AllocationUpdated",
 				},
-			}
+			},
+		}
 
-			return events, nil
-		},
-	}
+	}).Return(events, nil).Once()
 
-	reaper, err := NewEndpointReaper(cilium, nomad, nomadEventStream, "NodeID")
-	if err != nil {
-		t.Fatalf("unexpected error creating poller %v", err)
-	}
+	reaper, err := NewEndpointReaper(eum, aim, esm, "nodeID")
+	assert.Nil(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
 	failChan, err := reaper.Run(ctx)
-	if err != nil {
-		t.Fatalf("unexpected error running endpoint reaper %v", err)
-	}
+	assert.Nil(t, err, "unexpected error running endpoint reaper")
 
 	event := <-events
-	if event == nil {
-		t.Fatalf("expected left over event but got <nil>")
-	}
+	assert.NotNil(t, event, "expected left over event but got <nil>")
 
 	fail := <-failChan
-	if !fail {
-		t.Fatalf("expected fail but got <false>")
-	}
+	assert.True(t, fail, "expected fail but got <false>")
 
 	close(events)
 


### PR DESCRIPTION
The only identifier that is guaranteed to be on a Cilium endpoint is the CNI attachment ID. Previously the reconcile loop would look for the container ID but that can be empty string. The outcome was that the reconcile loop would skip over all endpoints rather than reconcile the labels.

Other parts of the code already used the CNI attachment ID correctly, so the reconcile loop now does too.

This change also updates the tests to use stretchr for mocks.
