### PR TITLE
Support parallel loading of policies.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.11.2
 	go.uber.org/zap v1.26.0
+	golang.org/x/sync v0.8.0
 )
 
 require (
@@ -126,7 +127,6 @@ require (
 	golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb // indirect
 	golang.org/x/net v0.26.0 // indirect
 	golang.org/x/oauth2 v0.21.0 // indirect
-	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.22.0 // indirect
 	golang.org/x/term v0.21.0 // indirect
 	golang.org/x/text v0.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -477,8 +477,8 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
-golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
+golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/reapers/policies.go
+++ b/reapers/policies.go
@@ -162,7 +162,7 @@ func (p *PoliciesReaper) reconcile(ctx context.Context, watcher *kvstore.Watcher
 	for oldKeyName := range oldPolicies {
 		labels := getIdentityLabels(oldKeyName)
 
-		zap.L().Info("Deleting local policy not found in kvstore", zap.Strings("labels", labels.GetModel()))
+		zap.L().Debug("Deleting local policy not found in kvstore", zap.Strings("labels", labels.GetModel()))
 
 		_, err := p.cilium.PolicyDelete(labels.GetModel())
 		if err != nil {
@@ -180,11 +180,11 @@ func (p *PoliciesReaper) reconcilePolicy(logger *zap.Logger, labels labels.Label
 	}
 
 	if oldRules.DeepEqual(newRules) {
-		logger.Info("Skipping unchanged policy", zap.Strings("labels", labels.GetModel()))
+		logger.Debug("Skipping unchanged policy", zap.Strings("labels", labels.GetModel()))
 		return nil
 	}
 
-	logger.Info("Creating policy", zap.Strings("labels", labels.GetModel()))
+	logger.Debug("Creating policy", zap.Strings("labels", labels.GetModel()))
 
 	rulesValue, err := json.Marshal(newRules)
 	if err != nil {
@@ -203,7 +203,7 @@ func (p *PoliciesReaper) handlePolicyEvent(logger *zap.Logger, keyName string, e
 	labels := getIdentityLabels(keyName)
 
 	if event.Typ == kvstore.EventTypeDelete {
-		logger.Info("Deleting policy", zap.Strings("labels", labels.GetModel()))
+		logger.Debug("Deleting policy", zap.Strings("labels", labels.GetModel()))
 
 		_, err := p.cilium.PolicyDelete(labels.GetModel())
 		if err != nil {
@@ -224,7 +224,7 @@ func (p *PoliciesReaper) handlePolicyEvent(logger *zap.Logger, keyName string, e
 	}
 
 	if event.Typ == kvstore.EventTypeCreate {
-		logger.Info("Creating policy", zap.Strings("labels", labels.GetModel()))
+		logger.Debug("Creating policy", zap.Strings("labels", labels.GetModel()))
 
 		_, err = p.cilium.PolicyReplace(string(newRulesValue), false, nil)
 		if err != nil {
@@ -245,11 +245,11 @@ func (p *PoliciesReaper) handlePolicyEvent(logger *zap.Logger, keyName string, e
 		}
 
 		if oldRules.DeepEqual(newRules) {
-			logger.Info("Ignoring unchanged policy", zap.Strings("labels", labels.GetModel()))
+			logger.Debug("Ignoring unchanged policy", zap.Strings("labels", labels.GetModel()))
 			return nil
 		}
 
-		logger.Info("Replacing policy", zap.Strings("labels", labels.GetModel()))
+		logger.Debug("Replacing policy", zap.Strings("labels", labels.GetModel()))
 
 		_, err = p.cilium.PolicyReplace(string(newRulesValue), false, labels.GetModel())
 		if err != nil {

--- a/reapers/policies_test.go
+++ b/reapers/policies_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -384,7 +385,10 @@ func TestSyncDeleteOrphan(t *testing.T) {
 		Typ: kvstore.EventTypeListDone,
 	}
 
-	policiesReaper.reconcile(context.Background(), watcher, 2)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+
+	policiesReaper.reconcile(ctx, watcher, 2)
 
 	assert.Len(t, cilium.rules, 2, "Failed to delete orphaned rule")
 	for _, r := range cilium.rules {

--- a/reapers/policies_test.go
+++ b/reapers/policies_test.go
@@ -1,6 +1,7 @@
 package reapers
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -9,6 +10,9 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"go.uber.org/zap"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type testPolicyRepository struct {
@@ -230,14 +234,10 @@ func TestModifyPolicyEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(cilium.rules) != 2 {
-		t.Fatalf("Should not have changed rule store size")
-	}
+	assert.Len(t, cilium.rules, 2, "Should not have changed rule store size")
 
 	// Modified rules get added to the end
-	if cilium.rules[1].Description != "one - modified" {
-		t.Fatalf("Failed to modify correct rule")
-	}
+	assert.Equal(t, "one - modified", cilium.rules[1].Description, "Failed to modify correct rule")
 }
 
 func TestModifyPolicyEventNoDifference(t *testing.T) {
@@ -335,78 +335,60 @@ func TestSyncDeleteOrphan(t *testing.T) {
 	}
 
 	policiesReaper, err := NewPoliciesReaper(nil, "", cilium)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	one := api.Rules{
 		api.NewRule().
 			WithDescription("one").
 			WithEndpointSelector(api.EndpointSelectorNone),
 	}
-
 	oneValue, err := json.Marshal(one)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	two := api.Rules{
 		api.NewRule().
 			WithDescription("two").
 			WithEndpointSelector(api.EndpointSelectorNone),
 	}
-
 	twoValue, err := json.Marshal(two)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	oldRules := api.Rules{
+	three := api.Rules{
 		api.NewRule().
 			WithDescription("three").
 			WithLabels(getIdentityLabels("three")).
 			WithEndpointSelector(api.EndpointSelectorNone),
 	}
 	oldPolicies := make(map[string]api.Rules)
-	oldPolicies["three"] = oldRules
+	oldPolicies["three"] = three
 
-	cilium.add(oldRules)
+	cilium.add(three)
 
-	err = policiesReaper.handleSyncPolicyEvent(zap.L(), oldPolicies, kvstore.KeyValueEvent{
+	eventsChan := make(chan kvstore.KeyValueEvent, 3)
+
+	watcher := &kvstore.Watcher{
+		Events: eventsChan,
+	}
+
+	eventsChan <- kvstore.KeyValueEvent{
 		Typ:   kvstore.EventTypeCreate,
 		Key:   "one",
 		Value: oneValue,
-	})
-	if err != nil {
-		t.Fatal(err)
 	}
-
-	policiesReaper.handleSyncPolicyEvent(zap.L(), oldPolicies, kvstore.KeyValueEvent{
+	eventsChan <- kvstore.KeyValueEvent{
 		Typ:   kvstore.EventTypeCreate,
 		Key:   "two",
 		Value: twoValue,
-	})
-	if err != nil {
-		t.Fatal(err)
 	}
-
-	policiesReaper.handleSyncPolicyEvent(zap.L(), oldPolicies, kvstore.KeyValueEvent{
+	eventsChan <- kvstore.KeyValueEvent{
 		Typ: kvstore.EventTypeListDone,
-	})
-	if err != nil {
-		t.Fatal(err)
 	}
 
-	if len(cilium.rules) != 2 {
-		t.Fatalf("Failed to delete orphaned rule")
-	}
+	policiesReaper.reconcile(context.Background(), watcher, 2)
 
-	if cilium.rules[0].Description != "one" {
-		t.Fatalf("Expected rule 'one', got : %v", cilium.rules[0])
-	}
-
-	if cilium.rules[1].Description != "two" {
-		t.Fatalf("Expected rule 'two', got : %v", cilium.rules[1])
+	assert.Len(t, cilium.rules, 2, "Failed to delete orphaned rule")
+	for _, r := range cilium.rules {
+		assert.NotEqual(t, r.Description, "three", "Failed to delete orphaned rule")
 	}
 
 }


### PR DESCRIPTION
This change introduces parallel loading of policies to the initial startup. When the policy set gets large it takes a very long time for netreap to complete policy loading.
